### PR TITLE
bump csso to 1.4.0, bump all other versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (optimise) {
         if (file.isStream()) {
             return done(new gutil.PluginError(PLUGIN_NAME, "Streaming not supported"));
         } else {
-            var optimised = csso.justDoIt(String(file.contents), optimise);
+            var optimised = csso.minify(String(file.contents), optimise);
             file.contents = new Buffer(optimised);
             stream.push(file);
             done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-csso",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Minify CSS with CSSO.",
   "license": "MIT",
   "homepage": "https://github.com/ben-eb/gulp-csso",
@@ -22,15 +22,15 @@
     "css"
   ],
   "dependencies": {
-    "csso": "~1.3.11",
-    "gulp-util": "~3.0.2"
+    "csso": "~1.4.0",
+    "gulp-util": "~3.0.6"
   },
   "devDependencies": {
-    "chai": "~1.10.0",
-    "event-stream": "~3.2.1",
-    "gulp": "~3.8.10",
-    "gulp-jshint": "~1.9.0",
-    "jshint-stylish": "~1.0.0",
+    "chai": "~3.3.0",
+    "event-stream": "~3.3.2",
+    "gulp": "~3.9.0",
+    "gulp-jshint": "~1.11.2",
+    "jshint-stylish": "~2.0.1",
     "mocha": "^2.1.0"
   },
   "main": "index.js"

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ describe('gulp-csso', function() {
     });
 
     it('should minify css with csso, with no structural optimisation', function(cb) {
-        var stream = csso(true);
+        var stream = csso({ restructuring: false });
 
         stream.on('data', function(data) {
             expect(String(data.contents)).to.equal(nonoptimal);


### PR DESCRIPTION
fix deprecated warning, fix test

csso 1.4.0 has a fix for this issue: https://github.com/css/csso/issues/231

which enables Bootstrap users to use structural optimization again!

I'm not familiar with the npm process to update this package in their db