### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# [gulp](https://github.com/wearefractal/gulp)-csso [![Build Status](https://travis-ci.org/ben-eb/gulp-csso.svg?branch=master)](https://travis-ci.org/ben-eb/gulp-csso) [![NPM version](https://badge.fury.io/js/gulp-csso.svg)](http://badge.fury.io/js/gulp-csso) [![Dependency Status](https://gemnasium.com/ben-eb/gulp-csso.svg)](https://gemnasium.com/ben-eb/gulp-csso)
+# [gulp](https://github.com/gulpjs/gulp)-csso [![Build Status](https://travis-ci.org/ben-eb/gulp-csso.svg?branch=master)](https://travis-ci.org/ben-eb/gulp-csso) [![NPM version](https://badge.fury.io/js/gulp-csso.svg)](http://badge.fury.io/js/gulp-csso) [![Dependency Status](https://gemnasium.com/ben-eb/gulp-csso.svg)](https://gemnasium.com/ben-eb/gulp-csso)
 
-> Minify CSS with [CSSO](https://npmjs.org/package/csso).
+> Minify CSS with [CSSO](https://www.npmjs.com/package/csso).
 
 *If you have any difficulties with the output of this plugin, please use the [CSSO tracker](https://github.com/css/csso/issues).*
 
 ## Install
 
-With [npm](https://npmjs.org/package/gulp-csso) do:
+With [npm](https://www.npmjs.com/package/gulp-csso) do:
 
 ```
 npm install gulp-csso --save-dev


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/wearefractal/gulp | https://github.com/gulpjs/gulp 


### Other Corrected URLs 
Was | Now 
--- | --- 
https://npmjs.org/package/csso | https://www.npmjs.com/package/csso 
https://npmjs.org/package/gulp-csso | https://www.npmjs.com/package/gulp-csso 
